### PR TITLE
fix: Handle relative path links in bullet lists gracefully

### DIFF
--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -188,6 +188,37 @@ lorem ipsum dolor sit amet.
 		assert.NoError(t, err)
 		assert.Equal(t, expected, result)
 	})
+	
+	t.Run("can handle bullet list with relative path links", func(t *testing.T) {
+		markdownText := `# How and Why Alpine Linux is used
+
+- [Building](./building.md)
+`
+		expected := []notion.Block{
+			notion.Heading1Block{
+				RichText: []notion.RichText{
+					{
+						Type:      notion.RichTextTypeText,
+						Text:      &notion.Text{Content: "How and Why Alpine Linux is used"},
+						PlainText: "How and Why Alpine Linux is used",
+					},
+				},
+			},
+			notion.BulletedListItemBlock{
+				RichText: []notion.RichText{
+					{
+						Type:      notion.RichTextTypeText,
+						Text:      &notion.Text{Content: "Building"},
+						PlainText: "Building",
+					},
+				},
+			},
+		}
+
+		result, err := Convert(markdownText)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, result)
+	})
 }
 
 func ExampleConvert() {

--- a/internal/converter/link.go
+++ b/internal/converter/link.go
@@ -37,15 +37,22 @@ func extractTitle(node *ast.Link) string {
 
 // convertLinkToTextBlock converts an AST link node to a Notion text block.
 // It takes a pointer to an ast.Link node and returns a Notion text block.
+// If the URL is invalid (like a relative path), it falls back to returning just the text content
+// without the link to prevent empty list items that would fail Notion API validation.
 func convertLinkToTextBlock(node *ast.Link) []notion.RichText {
 	if node == nil {
 		return nil
 	}
 
-	ok := isValidURL(extractURL(node))
+	url := extractURL(node)
+	title := extractTitle(node)
+	
+	ok := isValidURL(url)
 	if !ok {
-		return nil
+		// Fallback to plain text when URL validation fails
+		// This prevents empty list items when using relative paths
+		return chunk.RichText(title, nil)
 	}
 
-	return chunk.RichTextWithLink(extractTitle(node), extractURL(node))
+	return chunk.RichTextWithLink(title, url)
 }

--- a/internal/converter/link_test.go
+++ b/internal/converter/link_test.go
@@ -98,4 +98,29 @@ func TestConvertLinkToTextBlock(t *testing.T) {
 		result := convertLinkToTextBlock(node)
 		assert.Equal(t, expected, result)
 	})
+
+	t.Run("falls back to plain text for relative paths", func(t *testing.T) {
+		node := &ast.Link{
+			Destination: []byte("./building.md"),
+			Container: ast.Container{
+				Children: []ast.Node{
+					&ast.Leaf{
+						Literal: []byte("Building"),
+					},
+				},
+			},
+		}
+
+		// Expect plain text without link for invalid URLs
+		expected := []notion.RichText{{
+			Type:      notion.RichTextTypeText,
+			PlainText: "Building",
+			Text: &notion.Text{
+				Content: "Building",
+			},
+		}}
+
+		result := convertLinkToTextBlock(node)
+		assert.Equal(t, expected, result)
+	})
 }


### PR DESCRIPTION
Fixes #12 - This PR adds a fallback for invalid URLs (like relative paths) in bullet list items to prevent empty nodes that cause Notion API validation errors. Instead of returning nil for invalid URLs, we now return plain text without the link, ensuring the list item always has content.

This will not join markdown files from relative paths into the document or link them, it will purely write their text titles appropriately into the page.